### PR TITLE
Prevent model callbacks if deactivated

### DIFF
--- a/lib/meilisearch-rails.rb
+++ b/lib/meilisearch-rails.rb
@@ -418,7 +418,7 @@ module MeiliSearch
             proc.call(record, remove) if ::MeiliSearch::Rails.active? && !ms_without_auto_index_scope
           end
         end
-        unless options[:auto_index] == false
+        if ::MeiliSearch::Rails.active? && options[:auto_index] != false
           if defined?(::Sequel::Model) && self < Sequel::Model
             class_eval do
               copy_after_validation = instance_method(:after_validation)

--- a/spec/meilisearch/activation_spec.rb
+++ b/spec/meilisearch/activation_spec.rb
@@ -1,4 +1,5 @@
 require 'support/models/queued_models'
+require 'support/models/movie'
 
 describe MeiliSearch::Rails do
   it 'is active by default' do
@@ -23,6 +24,14 @@ describe MeiliSearch::Rails do
         expect do
           EnqueuedDocument.create! name: 'hello world'
         end.not_to raise_error
+      end
+
+      it 'does not run callbacks on save' do
+        movie = Movie.new(title: 'Harry Potter')
+        allow(movie).to receive(:ms_index!)
+        movie.save
+
+        expect(movie).not_to have_received(:ms_index!)
       end
     end
 


### PR DESCRIPTION
I realized later that, in fact, Meilisearch was disabled in my application, but since I didn't restart Sidekiq, it was still active there. As the application added items to the queue, Sidekiq attempted to communicate with the Meilisearch server, causing connection errors.

However, your PR helps a lot in my case, as it prevents the items from unnecessarily consuming Sidekiq's processing.

Finally, all of this made me reflect that it might be even better and cleaner to disable, in the first place, the callbacks added by meilisearch-rails.